### PR TITLE
Readme Walkthrough Suggestions

### DIFF
--- a/samples/weather/azure/README.md
+++ b/samples/weather/azure/README.md
@@ -43,12 +43,24 @@ Follow the steps below to provision the **WeatherService**, and the underlying r
     ```
     az --version
     ```
+    
+    In order to install or update the **Azure CLI** follow this [complete guide](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) or use the following instructions:
+
+    **macOS:** 
+    ```
+    brew update
+    brew install azure-cli
+    brew upgrade azure-cli
+    ```
+    **Windows:** [MSI installer](https://aka.ms/installazurecliwindows)
 
 3. Validate you have **.NET Core SDK** version *2.1* or higher
 
     ```
     dotnet --version
     ```
+
+    In order to install or update the SDK download the [.NET Core SDK Installer](https://dotnet.microsoft.com/download)
 
 ### Executing the provisioning script
 1. Open the **CMD** (if you do not have it open from the previous steps)
@@ -80,7 +92,7 @@ Follow the steps below to provision the **WeatherService**, and the underlying r
     - subscription_id
     - tenant_id
     - account_name
-7. Choose (or generate) an API key for **WeatherService**. There are a number of [guid generator](https://www.bing.com/search?q=guid+generator) tools available online which might help with this, however a passphrase would suffice for the purposes of this sample
+7. Choose (or generate) an API key for **WeatherService**. This API key will be used to prevent the **WeatherService** unauthorized access. Use it as the **your_api_key** parameter later. There are a number of [guid generator](https://www.bing.com/search?q=guid+generator) tools available online which might help with this, however a passphrase would suffice for the purposes of this sample
 8. From **CMD**, call the respective **weather_deploy** script passing in the requisite parameters. For example:
 
     **macOS:**

--- a/samples/weather/xamarin/README.md
+++ b/samples/weather/xamarin/README.md
@@ -40,26 +40,27 @@ The sample demonstrates analytics and crash reporting via [App Center](https://a
 
 To enable this you must [create an app in the App Center Portal](https://docs.microsoft.com/en-us/appcenter/sdk/getting-started/xamarin#2-create-your-app-in-the-app-center-portal-to-obtain-the-app-secret) for each platform.  
 
-Once you have created the apps, you can obtain the respective **App Secret** values on the **Getting Started** or **Manage App** sections of the [App Center Portal](https://appcenter.ms).  
+Once you have created the apps, you can obtain the **Android AppCenter App Secret** and **iOS AppCenter App Secret** values on the **Getting Started** or **Manage App** sections of the [App Center Portal](https://appcenter.ms).  
 
 ### 2. Provision the weather service
 The sample is underpinned by a [web service](https://github.com/xamarin/mobcat/tree/dev/samples/weather/azure), built with [asp.net core 2.1](https://dotnet.microsoft.com/download/dotnet-core/2.1), which you must host yourself in order to run the app. Once you have [provisioned the service to Azure](https://github.com/xamarin/mobcat/blob/dev/samples/weather/azure/README.md), you should have the following details for the service:  
 
-- **API Key** (you created this)
+- **API Key** (you created this as a part of the [executing the provisioning script](https://github.com/xamarin/mobcat/tree/dev/samples/weather/azure#executing-the-provisioning-script) step)
 - **API Endpoint URL** e.g. *https://<app_name>.azurewebsites.net/api/*
 
 ### 3. Set Environment Variables for the app secrets
-App secrets are resolved and set at built-time using our [MobCAT.ClientSecrets.Fody](https://github.com/xamarin/mobcat/tree/master/mobcat_client_secrets) add-in keeping the secrets out of the source code.   
+App secrets are resolved and set at built-time using our [MobCAT.ClientSecrets.Fody](https://github.com/xamarin/mobcat/tree/master/mobcat_client_secrets) add-in keeping the secrets out of the source code.
 
 The following app secrets are defined in the **ServiceConfig** class and are decorated by the `[ClientSecret]` attribute to denote that they will be set using an environment variable by the same name:
+
 1. WeatherServiceApiKey
 2. WeatherServiceUrl
 3. AndroidAppCenterSecret
 4. iOSAppCenterSecret
 
-To configure the environment variables: 
+To configure the environment variables:
 
-1. Open **Command Prompt/Terminal** 
+1. Open **Command Prompt/Terminal**
 2. Change directory to the **mobcat/samples/weather/xamarin/build** folder
 3. Execute the **environment** script passing in the requisite parameters. For example:
 
@@ -68,12 +69,14 @@ To configure the environment variables:
     ./environment.sh --api-key <API Key> --service-endpoint <API Endpoint URL> --android-appcenter-secret <Android AppCenter App Secret> --ios-appcenter-secret <iOS AppCenter App Secret>
     ```  
 
-    **Windows:**  
+    **Windows:**
     ```
     environment.bat --api-key <API Key> --service-endpoint <API Endpoint URL> --android-appcenter-secret <Android AppCenter App Secret> --ios-appcenter-secret <iOS AppCenter App Secret>
     ```
 
-    **NOTE:** You must restart **Visual Studio for Mac** in order for changes to these environment variables to be recognized (if it was open at the time these were set)
+    **NOTE:** You must restart **Visual Studio for Mac** in order for changes to these environment variables to be recognized (if it was open at the time these were set). If you need to update the value after it was initially set, please run the script again, restart the **Visual Studio for Mac** and rebuild the solution to apply the recent changes
+
+    **NOTE:** Make sure the **API Endpoint URL** ends with **/api/**
 
 ## Key Concepts
 


### PR DESCRIPTION
Based on my walkthrough I hit a few issues and wasn't able to run the sample from the first try, turned out the client secrets script wasn't working for me which forced me to manually set the secrets in code and run the sample. Today the script works just fine and I finished the walkthrough and made a few readme suggestions:

### WeatherService
- Updated the step to verify CLI & SDK version to provide information on how to actually update the tools in case of version mismatch
- Provided a reference for **--api-key <your_api_key>** in the description section, and added details why we need to generate this key and what is the alias used for it in one of the following scripts
- Kept it as is but probably worth updating... the folder paths are Windows like so you are unable to `cd` there by using the path copy/paste from the readme to terminal

### XamarinClient
- Provided a specific reference to the service provisioning guide to the point where we generated the API Key
- Updated names for the AppCenter constants to be used one-to-one with the names used by scripts the client secrets script: **Android AppCenter App Secret** and **iOS AppCenter App Secret**
- Updated notes to make sure the right API Url is used. I misconfigured it initially and spent some time trying to troubleshoot it and update the secrets
- Updated information on how to update the secrets once they were initially set, for me it wasn't enough just to restart the VS, I had to rebuild the solution to apply the change

