### PR TITLE
Fix layout for the settings page on android

### DIFF
--- a/samples/news/News/Pages/SettingsPage.xaml
+++ b/samples/news/News/Pages/SettingsPage.xaml
@@ -42,18 +42,19 @@
               HeightRequest="1"
               Grid.Row="1"/>
             
-            <Grid Grid.Row="2" Padding="15" Style="{DynamicResource backgroundStyle}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                
-                <!-- Theme Switch -->
-                <Label Style="{DynamicResource labelStyle}"
-                       Text="Light Mode"/>
-                <Switch AutomationId="LightModeSwitch"
-                        Grid.Column="1"
-                        IsToggled="{Binding IsLightMode}"/>
-            </Grid>
+        <Grid Grid.Row="2" Padding="15" Style="{DynamicResource backgroundStyle}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            
+            <!-- Theme Switch -->
+            <Label Style="{DynamicResource labelStyle}"
+                   Text="Light Mode"/>
+            <Switch AutomationId="LightModeSwitch"
+                    Grid.Column="1"
+                    VerticalOptions="Start"
+                    IsToggled="{Binding IsLightMode}"/>
+        </Grid>
     </Grid>
 </local:BaseContentPage>


### PR DESCRIPTION
This PR fixes the layout for android settings page:

**WAS**
![Screenshot_1552677261](https://user-images.githubusercontent.com/3697084/54457529-e0588780-471e-11e9-8adf-146ea6b3b913.png)

**Now**
![Screenshot_1552678207](https://user-images.githubusercontent.com/3697084/54457532-e64e6880-471e-11e9-81e4-68fe2ceaa044.png)

**iOS layout stays the same**
![Simulator Screen Shot - iPhone XS Max - 2019-03-15 at 12 34 15](https://user-images.githubusercontent.com/3697084/54457549-f36b5780-471e-11e9-8d50-3dc872182fbb.png)
