### PR TITLE
Restore calabash for AppCenter build

### DIFF
--- a/samples/news/News.iOS/AppDelegate.cs
+++ b/samples/news/News.iOS/AppDelegate.cs
@@ -8,11 +8,7 @@ namespace News.iOS
     {
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
-
-#if DEBUG
             Xamarin.Calabash.Start();
-#endif
-
             global::Xamarin.Forms.Forms.Init();
             LoadApplication(new App());
             Lottie.Forms.iOS.Renderers.AnimationViewRenderer.Init();


### PR DESCRIPTION
Currently, the AppCenter UI tests are failing because of missing `Xamarin.Calabash.Start()` call for the release configuration. This instruction was lost during one of the previously pushed changes to UI Tests and this PR restores that functionality.

Current error from the failing pipeline:

```
Starting test run... failed.
Error: The .ipa file does not seem to be linked with Calabash framework.

Further error details: For help, please send both the reported error above and the following environment information to us by going to https://appcenter.ms/apps and starting a new conversation (using the icon in the bottom right corner of the screen)

    Environment: darwin
    App Upload Id: Mobile-Customer-Advisory-Team/News.iOS-dev
    Timestamp: 1554226377130
    Operation: RunManifestTestsCommand
    Exit Code: 3
##[error]Error: /usr/local/bin/appcenter failed with return code: 3
##[section]Finishing: Test with Visual Studio App Center
```


